### PR TITLE
readResourceFile 

### DIFF
--- a/src/main/java/dev/comfast/util/Utils.java
+++ b/src/main/java/dev/comfast/util/Utils.java
@@ -1,12 +1,15 @@
 package dev.comfast.util;
 import lombok.SneakyThrows;
 
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
 import java.util.List;
 import java.util.stream.IntStream;
 
 import static java.lang.System.clearProperty;
 import static java.lang.System.getProperty;
 import static java.lang.System.setProperty;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.stream.Collectors.toList;
 
 public class Utils {
@@ -97,5 +100,23 @@ public class Utils {
                 return false;
             default: return true;
         }
+    }
+
+    /**
+     * Read resource file content.
+     * @param resourcePath e.g. fileNAme.txt or some/folder/file.txt
+     * @return file content
+     */
+    @SneakyThrows
+    public static String readResourceFile(String resourcePath) {
+        var stream = Utils.class.getClassLoader().getResourceAsStream(resourcePath);
+        if(stream == null) throw new RuntimeException("Not found resource file: " + resourcePath);
+        BufferedInputStream bis = new BufferedInputStream(stream);
+        ByteArrayOutputStream buf = new ByteArrayOutputStream();
+        for (int result = bis.read(); result != -1; result = bis.read()) {
+            buf.write((byte) result);
+        }
+
+        return buf.toString(UTF_8);
     }
 }

--- a/src/main/resources/some/test2.txt
+++ b/src/main/resources/some/test2.txt
@@ -1,0 +1,1 @@
+test2 content

--- a/src/main/resources/test.txt
+++ b/src/main/resources/test.txt
@@ -1,0 +1,1 @@
+test content

--- a/src/test/java/dev/comfast/util/UtilsTest.java
+++ b/src/test/java/dev/comfast/util/UtilsTest.java
@@ -5,10 +5,12 @@ import java.util.List;
 
 import static dev.comfast.util.Utils.isNullOrEmpty;
 import static dev.comfast.util.Utils.isTruthly;
+import static dev.comfast.util.Utils.readResourceFile;
 import static dev.comfast.util.Utils.transposeMatrix;
 import static dev.comfast.util.Utils.trimString;
 import static dev.comfast.util.Utils.withSystemProp;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -87,5 +89,13 @@ class UtilsTest {
         assertFalse(isNullOrEmpty(0.1f));
         assertFalse(isNullOrEmpty(0.1d));
         assertFalse(isNullOrEmpty(1L));
+    }
+
+    @Test void readResourceFileTest() {
+        assertThat(readResourceFile("test.txt")).isEqualTo("test content");
+        assertThat(readResourceFile("some/test2.txt")).isEqualTo("test2 content");
+
+        assertThatThrownBy(() -> readResourceFile("nothing.txt"))
+            .hasMessageContaining("Not found resource file: nothing.txt");
     }
 }


### PR DESCRIPTION
Short method to read resource files. Usable when to avoid import other IO library like Guava or Commons IO. 